### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true


### PR DESCRIPTION
Please do check to make sure these are the correct values for your code style! This will automatically configure editors which support `.editorconfig` (which is [basically all of them](https://editorconfig.org/#download)) when editing files in the sb-edit directory. Once we're sure these are the right values, we should add a `.editorconfig` scratch-js too - it makes development quite a bit more convenient for anyone working on the project.