### PR TITLE
Obsolete blocks

### DIFF
--- a/src/Block.ts
+++ b/src/Block.ts
@@ -138,6 +138,7 @@ export type KnownBlock =
   | BlockBase<OpCode.control_create_clone_of, { CLONE_OPTION: BlockInput.CloneTarget }>
   | BlockBase<OpCode.control_delete_this_clone, {}>
   | BlockBase<OpCode.control_for_each, { VARIABLE: BlockInput.Variable, VALUE: BlockInput.Number, SUBSTACK: BlockInput.Blocks }>
+  | BlockBase<OpCode.control_while, { CONDITION: BlockInput.Boolean, SUBSTACK: BlockInput.Blocks }>
 
   // Sensing
   | BlockBase<OpCode.sensing_touchingobject, { TOUCHINGOBJECTMENU: BlockInput.TouchingTarget }>

--- a/src/Block.ts
+++ b/src/Block.ts
@@ -138,8 +138,11 @@ export type KnownBlock =
   | BlockBase<OpCode.control_create_clone_of, { CLONE_OPTION: BlockInput.CloneTarget }>
   | BlockBase<OpCode.control_delete_this_clone, {}>
   | BlockBase<OpCode.control_all_at_once, { SUBSTACK: BlockInput.Blocks }>
-  | BlockBase<OpCode.control_for_each, { VARIABLE: BlockInput.Variable, VALUE: BlockInput.Number, SUBSTACK: BlockInput.Blocks }>
-  | BlockBase<OpCode.control_while, { CONDITION: BlockInput.Boolean, SUBSTACK: BlockInput.Blocks }>
+  | BlockBase<
+      OpCode.control_for_each,
+      { VARIABLE: BlockInput.Variable; VALUE: BlockInput.Number; SUBSTACK: BlockInput.Blocks }
+    >
+  | BlockBase<OpCode.control_while, { CONDITION: BlockInput.Boolean; SUBSTACK: BlockInput.Blocks }>
 
   // Sensing
   | BlockBase<OpCode.sensing_touchingobject, { TOUCHINGOBJECTMENU: BlockInput.TouchingTarget }>

--- a/src/Block.ts
+++ b/src/Block.ts
@@ -137,6 +137,7 @@ export type KnownBlock =
   | BlockBase<OpCode.control_start_as_clone, {}>
   | BlockBase<OpCode.control_create_clone_of, { CLONE_OPTION: BlockInput.CloneTarget }>
   | BlockBase<OpCode.control_delete_this_clone, {}>
+  | BlockBase<OpCode.control_all_at_once, { SUBSTACK: BlockInput.Blocks }>
   | BlockBase<OpCode.control_for_each, { VARIABLE: BlockInput.Variable, VALUE: BlockInput.Number, SUBSTACK: BlockInput.Blocks }>
   | BlockBase<OpCode.control_while, { CONDITION: BlockInput.Boolean, SUBSTACK: BlockInput.Blocks }>
 

--- a/src/Block.ts
+++ b/src/Block.ts
@@ -137,6 +137,7 @@ export type KnownBlock =
   | BlockBase<OpCode.control_start_as_clone, {}>
   | BlockBase<OpCode.control_create_clone_of, { CLONE_OPTION: BlockInput.CloneTarget }>
   | BlockBase<OpCode.control_delete_this_clone, {}>
+  | BlockBase<OpCode.control_for_each, { VARIABLE: BlockInput.Variable, VALUE: BlockInput.Number, SUBSTACK: BlockInput.Blocks }>
 
   // Sensing
   | BlockBase<OpCode.sensing_touchingobject, { TOUCHINGOBJECTMENU: BlockInput.TouchingTarget }>

--- a/src/BlockInput.ts
+++ b/src/BlockInput.ts
@@ -99,6 +99,12 @@ export interface RotationStyle extends Base {
   value: string;
 }
 
+// Deprecated field for "align scene" block.
+export interface ScrollAlignment extends Base {
+  type: "scrollAlignment";
+  value: string;
+}
+
 export interface PenColorParam extends Base {
   type: "penColorParam";
   value: string;
@@ -254,6 +260,7 @@ export type FieldAny =
   | GoToTarget
   | PointTowardsTarget
   | RotationStyle
+  | ScrollAlignment
   | PenColorParam
   | Key
   | GreaterThanMenu

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -249,7 +249,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
         [OpCode.motion_pointtowards_menu]: { TOWARDS: "pointTowardsTarget" },
         [OpCode.motion_glideto_menu]: { TO: "goToTarget" },
         [OpCode.motion_goto_menu]: { TO: "goToTarget" },
-        [OpCode.motion_align_scene]: { ALIGNMENT: "string" }, // obsolete no-op so the value really doesn't matter
+        [OpCode.motion_align_scene]: { ALIGNMENT: "scrollAlignment" },
         [OpCode.looks_costume]: { COSTUME: "costume" },
         [OpCode.looks_gotofrontback]: { FRONT_BACK: "frontBackMenu" },
         [OpCode.looks_goforwardbackwardlayers]: { FORWARD_BACKWARD: "forwardBackwardMenu" },

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -249,6 +249,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
         [OpCode.motion_pointtowards_menu]: { TOWARDS: "pointTowardsTarget" },
         [OpCode.motion_glideto_menu]: { TO: "goToTarget" },
         [OpCode.motion_goto_menu]: { TO: "goToTarget" },
+        [OpCode.motion_align_scene]: { ALIGNMENT: "string" }, // obsolete no-op so the value really doesn't matter
         [OpCode.looks_costume]: { COSTUME: "costume" },
         [OpCode.looks_gotofrontback]: { FRONT_BACK: "frontBackMenu" },
         [OpCode.looks_goforwardbackwardlayers]: { FORWARD_BACKWARD: "forwardBackwardMenu" },

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -266,6 +266,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
         [OpCode.event_whenbroadcastreceived]: { BROADCAST_OPTION: "broadcast" },
         [OpCode.control_stop]: { STOP_OPTION: "stopMenu" },
         [OpCode.control_create_clone_of_menu]: { CLONE_OPTION: "cloneTarget" },
+        [OpCode.control_for_each]: { VARIABLE: "variable" },
         [OpCode.sensing_touchingobjectmenu]: { TOUCHINGOBJECTMENU: "touchingTarget" },
         [OpCode.sensing_distancetomenu]: { DISTANCETOMENU: "distanceToMenu" },
         [OpCode.sensing_keyoptions]: { KEY_OPTION: "key" },

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -438,7 +438,7 @@ export default function toScratchJS(
         case OpCode.control_wait_until:
           return `while (!(${inputToJS(block.inputs.CONDITION)})) { yield; }`;
         case OpCode.control_repeat_until:
-          return `while(!(${inputToJS(block.inputs.CONDITION)})) {
+          return `while (!(${inputToJS(block.inputs.CONDITION)})) {
             ${inputToJS(block.inputs.SUBSTACK)};
             ${warp ? "" : "yield;"}
           }`;
@@ -776,9 +776,9 @@ export default function toScratchJS(
 
           <script type="module">
             import project from ${JSON.stringify(options.indexURL)};
-      
+
             project.attach("#project");
-      
+
             document
               .querySelector("#greenFlag")
               .addEventListener("click", () => {

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -442,6 +442,11 @@ export default function toScratchJS(
             ${inputToJS(block.inputs.SUBSTACK)}
             ${warp ? "" : "yield;"}
           }`;
+        case OpCode.control_while:
+          return `while (${inputToJS(block.inputs.CONDITION)}) {
+            ${inputToJS(block.inputs.SUBSTACK)}
+            ${warp ? "" : "yield;"}
+          }`;
         case OpCode.control_for_each:
           return `for (${selectedVarSource} = 1; ${selectedVarSource} <= (${inputToJS(block.inputs.VALUE)}); ${selectedVarSource}++) {
             ${inputToJS(block.inputs.SUBSTACK)}

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -461,7 +461,9 @@ export default function toScratchJS(
             ${warp ? "" : "yield;"}
           }`;
         case OpCode.control_for_each:
-          return `for (${selectedVarSource} = 1; ${selectedVarSource} <= (${inputToJS(block.inputs.VALUE)}); ${selectedVarSource}++) {
+          return `for (${selectedVarSource} = 1; ${selectedVarSource} <= (${inputToJS(
+            block.inputs.VALUE
+          )}); ${selectedVarSource}++) {
             ${inputToJS(block.inputs.SUBSTACK)}
             ${warp ? "" : "yield;"}
           }`;

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -348,6 +348,14 @@ export default function toScratchJS(
           return `this.y`;
         case OpCode.motion_direction:
           return `this.direction`;
+        // Obsolete no-op blocks:
+        case OpCode.motion_scroll_right:
+        case OpCode.motion_scroll_up:
+        case OpCode.motion_align_scene:
+          return ``;
+        case OpCode.motion_xscroll:
+        case OpCode.motion_yscroll:
+          return `undefined`; // Compatibility with Scratch 3.0 \:)/
         case OpCode.looks_sayforsecs:
           return `yield* this.sayAndWait((${inputToJS(block.inputs.MESSAGE)}), (${inputToJS(block.inputs.SECS)}))`;
         case OpCode.looks_say:

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -439,7 +439,12 @@ export default function toScratchJS(
           return `while (!(${inputToJS(block.inputs.CONDITION)})) { yield; }`;
         case OpCode.control_repeat_until:
           return `while (!(${inputToJS(block.inputs.CONDITION)})) {
-            ${inputToJS(block.inputs.SUBSTACK)};
+            ${inputToJS(block.inputs.SUBSTACK)}
+            ${warp ? "" : "yield;"}
+          }`;
+        case OpCode.control_for_each:
+          return `for (${selectedVarSource} = 1; ${selectedVarSource} <= (${inputToJS(block.inputs.VALUE)}); ${selectedVarSource}++) {
+            ${inputToJS(block.inputs.SUBSTACK)}
             ${warp ? "" : "yield;"}
           }`;
         case OpCode.control_stop:

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -452,6 +452,8 @@ export default function toScratchJS(
             ${inputToJS(block.inputs.SUBSTACK)}
             ${warp ? "" : "yield;"}
           }`;
+        case OpCode.control_all_at_once:
+          return inputToJS(block.inputs.SUBSTACK);
         case OpCode.control_stop:
           switch (block.inputs.STOP_OPTION.value) {
             case "this script":

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -484,11 +484,11 @@ export default function toScratchJS(
         case OpCode.control_delete_this_clone:
           return `this.deleteThisClone()`;
         case OpCode.control_get_counter:
-          return `${stage}.counter`;
+          return `${stage}.__counter`;
         case OpCode.control_incr_counter:
-          return `${stage}.counter++`;
+          return `${stage}.__counter++`;
         case OpCode.control_clear_counter:
-          return `${stage}.counter = 0`;
+          return `${stage}.__counter = 0`;
         case OpCode.sensing_touchingobject:
           switch (block.inputs.TOUCHINGOBJECTMENU.value) {
             case "_mouse_":

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -393,6 +393,11 @@ export default function toScratchJS(
           return `this.visible = true`;
         case OpCode.looks_hide:
           return `this.visible = false`;
+        // Obsolete no-op blocks:
+        case OpCode.looks_hideallsprites:
+        case OpCode.looks_changestretchby:
+        case OpCode.looks_setstretchto:
+          return ``;
         case OpCode.looks_costumenumbername:
           switch (block.inputs.NUMBER_NAME.value) {
             case "name":
@@ -617,6 +622,8 @@ export default function toScratchJS(
           return `(((new Date().getTime() - new Date(2000, 0, 1)) / 1000 / 60 + new Date().getTimezoneOffset()) / 60 / 24)`;
         case OpCode.sensing_username:
           return `(/* no username */ "")`;
+        case OpCode.sensing_userid:
+          return `undefined`; // Obsolete no-op block.
         case OpCode.operator_add:
           return `((${inputToJS(block.inputs.NUM1)}) + (${inputToJS(block.inputs.NUM2)}))`;
         case OpCode.operator_subtract:

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -470,6 +470,12 @@ export default function toScratchJS(
           }
         case OpCode.control_delete_this_clone:
           return `this.deleteThisClone()`;
+        case OpCode.control_get_counter:
+          return `${stage}.counter`;
+        case OpCode.control_incr_counter:
+          return `${stage}.counter++`;
+        case OpCode.control_clear_counter:
+          return `${stage}.counter = 0`;
         case OpCode.sensing_touchingobject:
           switch (block.inputs.TOUCHINGOBJECTMENU.value) {
             case "_mouse_":


### PR DESCRIPTION
(PullJosh/scratch-js#42 must be merged before this PR.)

This PR completes support for loading obsolete blocks and adds support for exporting them to scratch-js. Obsolete blocks are defined as the following (mostly copied [from here](https://github.com/LLK/scratch-vm/issues/355#issuecomment-379399646)):

- [x] `doForLoop`: ___. See [here](https://github.com/LLK/scratch-vm/blob/develop/src/blocks/scratch3_control.js#L84-L97) for its most up-to-date behavior (it was kinda glitchy in 2.0 IIRC).
- [x] `doWhile`: ___. [Its behavior](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/interpreter/Interpreter.as#L456) is exactly the opposite of `doUntil` (i.e. "repeat until"): while the condition is true (rather than false), run the contained blocks.
- [x] `warpSpeed` ("all at once"): ___. [Its behavior](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/interpreter/Interpreter.as#L542-L546) is to run the contained blocks as they are (don't actually go into "warp speed", i.e. no-refresh). ("all at once: { move 10 steps, turn 15 degrees }" is functionally equivalent to "move 10 steps, turn 15 degrees".)
- [x] [Counter blocks](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/Specs.as#L378-L381): ___.
  - The counter value is a global value that defaults to zero.
  - `counter`: Return the counter value.
  - `incr counter`: Increment the counter's value by one.
  - `clear counter`: Set the counter value to zero.
- [x] [Scroll blocks](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/Specs.as#L386-L391): ___. These are all no-ops.
- [x] ["hide all sprites", "user id"](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/Specs.as#L393-L395), and those suspicious "setStretchTo" and "changeStretchBy" blocks: ___. Also no-ops.
- ["loud?"](https://github.com/LLK/scratch-flash/blob/96a2a9a7fca2d042da25dc0d4423900163ab4f33/src/Specs.as#L366): ___. [Its behavior](https://github.com/LLK/scratch-flash/blob/996a2911dd425892f0b4224f5998bce38f964481/src/scratch/ScratchRuntime.as#L1125) is to return whether or not the sound level (i.e. result of "loudness") is greater than 10 (so it's identical to `loudness > 10`). (Not a checkbox since "loudness" hasn't been implemented in scratch-js yet.)
- [Various 1.4 blocks](https://github.com/LLK/scratch-flash/blob/9fbac92ef3d09ceca0c0782f8a08deaa79e4df69/src/Specs.as#L368-L375) that should automatically be converted to their 2.0+ forms. (Not a checkbox since this will be looked at separately from other obsolete blocks - sb-edit doesn't support 1.4 import yet and I'm pretty sure any projects saved in 2.0 or 3.0 will automatically have converted these to the 2.0+ form.)
  - `abs (val)` -> `("abs") of (val)`
  - `sqrt (val)` -> `("sqrt") of (val)`
  - `stop script` -> `stop ("this script")`
  - `stop all` -> `stop ("all")`
  - `switch to background (bg)` -> `switch backdrop to (bg)`
  - `next background` -> `next backdrop`
  - `forever if (cond): (script)` -> `forever: if (cond): (script)`

This PR resolves PullJosh/scratch-js#41.