### PR TITLE
Add support for more extension menus

### DIFF
--- a/src/BlockInput.ts
+++ b/src/BlockInput.ts
@@ -104,6 +104,52 @@ export interface PenColorParam extends Base {
   value: string;
 }
 
+export interface MusicDrum extends Base {
+  type: "musicDrum";
+  value: string;
+}
+
+export interface MusicInstrument extends Base {
+  type: "musicInstrument";
+  // There's technically only specific values this menu can take, but there's so many choices it doesn't seem reasonable to copy them all here.
+  value: string;
+}
+
+export interface VideoSensingAttribute extends Base {
+  type: "videoSensingAttribute";
+  value: "motion" | "direction";
+}
+
+export interface VideoSensingSubject extends Base {
+  type: "videoSensingSubject";
+  value: "Stage" | "this sprite";
+}
+
+export interface VideoSensingVideoState extends Base {
+  type: "videoSensingVideoState";
+  value: "off" | "on" | "on-flipped";
+}
+
+export interface WeDo2MotorId extends Base {
+  type: "wedo2MotorId";
+  value: "motor" | "motor A" | "motor B" | "all motors";
+}
+
+export interface WeDo2MotorDirection extends Base {
+  type: "wedo2MotorDirection";
+  value: "this way" | "that way" | "reverse";
+}
+
+export interface WeDo2TiltDirection extends Base {
+  type: "wedo2TiltDirection";
+  value: "up" | "down" | "left" | "right";
+}
+
+export interface WeDo2TiltDirectionAny extends Base {
+  type: "wedo2TiltDirectionAny";
+  value: "up" | "down" | "left" | "right" | "any";
+}
+
 export interface Key extends Base {
   type: "key";
   value:
@@ -255,6 +301,15 @@ export type FieldAny =
   | PointTowardsTarget
   | RotationStyle
   | PenColorParam
+  | MusicDrum
+  | MusicInstrument
+  | VideoSensingAttribute
+  | VideoSensingSubject
+  | VideoSensingVideoState
+  | WeDo2MotorId
+  | WeDo2MotorDirection
+  | WeDo2TiltDirection
+  | WeDo2TiltDirectionAny
   | Key
   | GreaterThanMenu
   | StopMenu

--- a/src/OpCode.ts
+++ b/src/OpCode.ts
@@ -189,8 +189,8 @@ export enum OpCode {
   control_incr_counter = "control_incr_counter",
   control_clear_counter = "control_clear_counter",
   control_all_at_once = "control_all_at_once",
-  sensing_userid = "sensing_userid",
 
+  sensing_userid = "sensing_userid",
   sensing_loud = "sensing_loud",
 
   music_midiPlayDrumForBeats = "music_midiPlayDrumForBeats",
@@ -222,5 +222,17 @@ export enum OpCode {
   sensing_keyoptions = "sensing_keyoptions",
   sensing_of_object_menu = "sensing_of_object_menu",
 
-  pen_menu_colorParam = "pen_menu_colorParam"
+  pen_menu_colorParam = "pen_menu_colorParam",
+
+  music_menu_DRUM = "music_menu_DRUM",
+  music_menu_INSTRUMENT = "music_menu_INSTRUMENT",
+
+  videoSensing_menu_ATTRIBUTE = "videoSensing_menu_ATTRIBUTE",
+  videoSensing_menu_SUBJECT = "videoSensing_menu_SUBJECT",
+  videoSensing_menu_VIDEO_STATE = "videoSensing_menu_VIDEO_STATE",
+
+  wedo2_menu_MOTOR_ID = "wedo2_menu_MOTOR_ID",
+  wedo2_menu_MOTOR_DIRECTION = "wedo2_MOTOR_DIRECTION",
+  wedo2_menu_TILT_DIRECTION = "wedo2_TILT_DIRECTION",
+  wedo2_menu_TILT_DIRECTION_ANY = "wedo2_TILT_DIRECTION_ANY"
 }

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -293,7 +293,16 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
         [OpCode.data_hidelist]: { LIST: "list" },
         [OpCode.argument_reporter_string_number]: { VALUE: "string" },
         [OpCode.argument_reporter_boolean]: { VALUE: "string" },
-        [OpCode.pen_menu_colorParam]: { colorParam: "penColorParam" }
+        [OpCode.pen_menu_colorParam]: { colorParam: "penColorParam" },
+        [OpCode.music_menu_DRUM]: { DRUM: "musicDrum" },
+        [OpCode.music_menu_INSTRUMENT]: { INSTRUMENT: "musicInstrument" },
+        [OpCode.videoSensing_menu_ATTRIBUTE]: { ATTRIBUTE: "videoSensingAttribute" },
+        [OpCode.videoSensing_menu_SUBJECT]: { SUBJECT: "videoSensingSubject" },
+        [OpCode.videoSensing_menu_VIDEO_STATE]: { VIDEO_STATE: "videoSensingVideoState" },
+        [OpCode.wedo2_menu_MOTOR_ID]: { MOTOR_ID: "wedo2MotorId" },
+        [OpCode.wedo2_menu_MOTOR_DIRECTION]: { MOTOR_DIRECTION: "wedo2MotorDirection" },
+        [OpCode.wedo2_menu_TILT_DIRECTION]: { TILT_DIRECTION: "wedo2TiltDirection" },
+        [OpCode.wedo2_menu_TILT_DIRECTION_ANY]: { TILT_DIRECTION_ANY: "wedo2TiltDirectionAny" }
       };
 
       let result = {};


### PR DESCRIPTION
This PR adds only the menus from the extensions whose non-menu opcodes were already present in the list (specifically Music, Video Sensing, and WeDo 2.0).

Incoming soon™ scratchblocks PR will depend on this, since it'll be implementing the blocks and menus from these extensions.

As for the other extensions - there should probably be separate discussion on that before putting work into porting over all of them. (There's like... 10+ now or something! :P)