### PR TITLE
Scratchblocks Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ sb-edit is a javascript library for manipulating Scratch project files.
 
 sb-edit allows importing and exporting a variety of Scratch project file types:
 
-| File Format                                          | Import         | Export         |
-| ---------------------------------------------------- | -------------- | -------------- |
-| Scratch 3.0 (**.sb3**)                               | 🚧 In progress | 🕒 Planned     |
-| Scratch 2.0 (**.sb2**)                               | 🕒 Planned     | 🕒 Planned     |
-| [scratch-js](https://github.com/PullJosh/scratch-js) | ❌ No          | 🚧 In progress |
+| File Format                                            | Import         | Export         |
+| ------------------------------------------------------ | -------------- | -------------- |
+| Scratch 3.0 (**.sb3**)                                 | 🚧 In progress | 🕒 Planned     |
+| Scratch 2.0 (**.sb2**)                                 | 🕒 Planned     | 🕒 Planned     |
+| [scratch-js](https://github.com/PullJosh/scratch-js)   | ❌ No          | 🚧 In progress |
+| [scratchblocks](https://github.com/tjvr/scratchblocks) | 🚧 In progress | 👻 Maybe!      |
 
 ## Editing
 

--- a/src/BlockInput.ts
+++ b/src/BlockInput.ts
@@ -99,6 +99,12 @@ export interface RotationStyle extends Base {
   value: string;
 }
 
+// Deprecated field for "align scene" block.
+export interface ScrollAlignment extends Base {
+  type: "scrollAlignment";
+  value: string;
+}
+
 export interface PenColorParam extends Base {
   type: "penColorParam";
   value: string;
@@ -254,6 +260,7 @@ export type FieldAny =
   | GoToTarget
   | PointTowardsTarget
   | RotationStyle
+  | ScrollAlignment
   | PenColorParam
   | Key
   | GreaterThanMenu

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -3,6 +3,7 @@ import { Sprite, Stage } from "./Target";
 import fromSb3, { fromSb3JSON } from "./io/sb3/fromSb3";
 import toSb3 from "./io/sb3/toSb3";
 import toScratchJS from "./io/scratch-js/toScratchJS";
+import toScratchblocks from "./io/scratchblocks/toScratchblocks";
 
 type TextToSpeechLanguage =
   | "ar"
@@ -34,6 +35,7 @@ export default class Project {
   public static fromSb3JSON = fromSb3JSON;
 
   public toScratchJS: typeof toScratchJS = toScratchJS.bind(this);
+  public toScratchblocks: typeof toScratchblocks = toScratchblocks.bind(this);
 
   public stage: Stage = new Stage();
   public sprites: Sprite[] = [];

--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -359,9 +359,9 @@ when I receive [message1 v]
 broadcast (message1 v)
 broadcast (message1 v) and wait
 ask ((5) + (pick random ((8) / (4)) to (10))) and wait
-ask ([] - []) and wait
-ask ([] * []) and wait
-ask ([] / []) and wait
+ask (() - ()) and wait
+ask (() * ()) and wait
+ask (() / ()) and wait
 ask <<[] < [50]> and <[] > [50]>> and wait
 ask <<[] = [50]> or []> and wait
 ask <not <>> and wait
@@ -369,7 +369,7 @@ ask (join [apple ] (letter (1) of [apple])) and wait
 ask (length of [apple]) and wait
 ask <[apple] contains [a] ? :: operators> and wait
 ask ((12) mod (7)) and wait
-ask (round []) and wait
+ask (round ()) and wait
 ask ([10 ^ v] of (15)) and wait
 
 define block name <boolean> label text (number or text) // run without screen refresh

--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -263,9 +263,9 @@ exports[`sb3 -> scratchblocks 1`] = `
 Object {
   "Abby": "<touching [#859dde] ?>
 
-<[#ee9128] is touching [#935b58] ?>
+<color [#ee9128] is touching [#935b58] ?>
 
-(distance to (_mouse_ v))
+(distance to (mouse-pointer v))
 
 set drag mode [not draggable v]
 
@@ -275,50 +275,50 @@ move (10) steps
 when [any v] key pressed
 turn cw (costume [number v]) degrees
 turn ccw (15) degrees
-go to (_random_ v)
+go to (random position v)
 go to x: (y position) y: (-23)
-glide (1) secs to (_mouse_ v)
+glide (1) secs to (mouse-pointer v)
 glide (1) secs to x: (-36) y: (x position)
 point in direction (90)
-point towards (_mouse_ v)
+point towards (mouse-pointer v)
 change x by (direction)
 set x to (-36)
 change y by (10)
 set y to (-23)
 if on edge, bounce
 set rotation style [left-right v]
-create clone of (_myself_ v)
+create clone of (myself v)
 delete this clone",
   "Stage": "when green flag clicked
 switch backdrop to (backdrop1 v)
 switch backdrop to (next backdrop v) and wait
 next backdrop
-change [COLOR v] effect by (backdrop [number v]) :: looks
-set [COLOR v] effect to (backdrop [name v]) :: looks
+change [color v] effect by (backdrop [number v]) :: looks
+set [color v] effect to (backdrop [name v]) :: looks
 clear graphic effects
 
 when [space v] key pressed
 play sound (pop v) until done
 start sound (pop v)
 stop all sounds
-change [PAN v] effect by (10) :: sound
-set [PAN v] effect to (volume) :: sound
+change [pan left/right v] effect by (10) :: sound
+set [pan left/right v] effect to (volume) :: sound
 clear sound effects
 change volume by (-10)
 set volume to (100) %
 
-when stage clicked
+when stage clicked :: control hat
 ask [What's your name?] and wait
 ask (answer) and wait
-ask (<key (space v) pressed?>) and wait
-ask (<mouse down?>) and wait
+ask <key (space v) pressed?> and wait
+ask <mouse down?> and wait
 ask (mouse x) and wait
 ask (mouse y) and wait
 ask (loudness) and wait
 ask (timer) and wait
-ask ([backdrop # v] of (_stage_ v)) and wait
-ask ([☁ cloud var v] of (_stage_ v)) and wait
-ask (current [DAYOFWEEK v]) and wait
+ask ([backdrop # v] of (Stage v)) and wait
+ask ([☁ cloud var v] of (Stage v)) and wait
+ask (current [day of week v]) and wait
 ask (days since 2000) and wait
 ask (username) and wait
 reset timer
@@ -328,8 +328,8 @@ wait (1) seconds
 wait until <>
 create clone of ( v)
 repeat (10)
-	repeat until (<key (space v) pressed?>)
-		if (<mouse down?>) then
+	repeat until <key (space v) pressed?>
+		if <mouse down?> then
 			if <> then
 			else
 			end
@@ -340,14 +340,14 @@ end
 forever
 end
 
-when [LOUDNESS v] > (10)
+when [loudness v] > (10)
 set [☁ cloud var v] to (my variable :: variables)
 change [☁ cloud var v] by (1)
 set [my variable v] to [0]
 change [my variable v] by (☁ cloud var :: variables)
 show variable [☁ cloud var v]
 hide variable [my variable v]
-add (<[test list v] contains [thing] ? :: list>) to [test list v]
+add <[test list v] contains [thing] ? :: list> to [test list v]
 delete (1) of [test list v]
 delete all of [test list v]
 insert [thing] at (item # of [thing] in [test list v]) of [test list v]
@@ -359,22 +359,22 @@ when I receive [message1 v]
 broadcast (message1 v)
 broadcast (message1 v) and wait
 ask ((5) + (pick random ((8) / (4)) to (10))) and wait
-ask (() - ()) and wait
-ask (() * ()) and wait
-ask (() / ()) and wait
-ask (<(<[] < [50]>) and (<[] > [50]>)>) and wait
-ask (<(<[] = [50]>) or []>) and wait
-ask (<not <>>) and wait
+ask ([] - []) and wait
+ask ([] * []) and wait
+ask ([] / []) and wait
+ask <<[] < [50]> and <[] > [50]>> and wait
+ask <<[] = [50]> or []> and wait
+ask <not <>> and wait
 ask (join [apple ] (letter (1) of [apple])) and wait
 ask (length of [apple]) and wait
-ask (<[apple] contains [a] ? :: operators>) and wait
+ask <[apple] contains [a] ? :: operators> and wait
 ask ((12) mod (7)) and wait
-ask (round ()) and wait
+ask (round []) and wait
 ask ([10 ^ v] of (15)) and wait
 
 define block name <boolean> label text (number or text) // run without screen refresh
 play sound (number or text :: custom-arg) until done
-if (<boolean :: custom-arg>) then
+if <boolean :: custom-arg> then
 end",
 }
 `;

--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -258,3 +258,123 @@ export default project;
 ",
 }
 `;
+
+exports[`sb3 -> scratchblocks 1`] = `
+Object {
+  "Abby": "<touching [#859dde] ?>
+
+<[#ee9128] is touching [#935b58] ?>
+
+(distance to (_mouse_ v))
+
+set drag mode [not draggable v]
+
+when I start as a clone
+move (10) steps
+
+when [any v] key pressed
+turn cw (costume [number v]) degrees
+turn ccw (15) degrees
+go to (_random_ v)
+go to x: (y position) y: (-23)
+glide (1) secs to (_mouse_ v)
+glide (1) secs to x: (-36) y: (x position)
+point in direction (90)
+point towards (_mouse_ v)
+change x by (direction)
+set x to (-36)
+change y by (10)
+set y to (-23)
+if on edge, bounce
+set rotation style [left-right v]
+create clone of (_myself_ v)
+delete this clone",
+  "Stage": "when green flag clicked
+switch backdrop to (backdrop1 v)
+switch backdrop to (next backdrop v) and wait
+next backdrop
+change [COLOR v] effect by (backdrop [number v]) :: looks
+set [COLOR v] effect to (backdrop [name v]) :: looks
+clear graphic effects
+
+when [space v] key pressed
+play sound (pop v) until done
+start sound (pop v)
+stop all sounds
+change [PAN v] effect by (10) :: sound
+set [PAN v] effect to (volume) :: sound
+clear sound effects
+change volume by (-10)
+set volume to (100) %
+
+when stage clicked
+ask [What's your name?] and wait
+ask (answer) and wait
+ask (<key (space v) pressed?>) and wait
+ask (<mouse down?>) and wait
+ask (mouse x) and wait
+ask (mouse y) and wait
+ask (loudness) and wait
+ask (timer) and wait
+ask ([backdrop # v] of (_stage_ v)) and wait
+ask ([☁ cloud var v] of (_stage_ v)) and wait
+ask (current [DAYOFWEEK v]) and wait
+ask (days since 2000) and wait
+ask (username) and wait
+reset timer
+
+when backdrop switches to [backdrop1 v]
+wait (1) seconds
+wait until <>
+create clone of ( v)
+repeat (10)
+	repeat until (<key (space v) pressed?>)
+		if (<mouse down?>) then
+			if <> then
+			else
+			end
+		end
+	end
+	stop [all v]
+end
+forever
+end
+
+when [LOUDNESS v] > (10)
+set [☁ cloud var v] to (my variable :: variables)
+change [☁ cloud var v] by (1)
+set [my variable v] to [0]
+change [my variable v] by (☁ cloud var :: variables)
+show variable [☁ cloud var v]
+hide variable [my variable v]
+add (<[test list v] contains [thing] ? :: list>) to [test list v]
+delete (1) of [test list v]
+delete all of [test list v]
+insert [thing] at (item # of [thing] in [test list v]) of [test list v]
+replace item (item (1) of [test list v]) of [test list v] with (length of [test list v])
+show list [test list v]
+hide list [test list v]
+
+when I receive [message1 v]
+broadcast (message1 v)
+broadcast (message1 v) and wait
+ask ((5) + (pick random ((8) / (4)) to (10))) and wait
+ask (() - ()) and wait
+ask (() * ()) and wait
+ask (() / ()) and wait
+ask (<(<[] < [50]>) and (<[] > [50]>)>) and wait
+ask (<(<[] = [50]>) or []>) and wait
+ask (<not <>>) and wait
+ask (join [apple ] (letter (1) of [apple])) and wait
+ask (length of [apple]) and wait
+ask (<[apple] contains [a] ? :: operators>) and wait
+ask ((12) mod (7)) and wait
+ask (round ()) and wait
+ask ([10 ^ v] of (15)) and wait
+
+define block name <boolean> label text (number or text) // run without screen refresh
+play sound (number or text :: custom-arg) until done
+if (<boolean :: custom-arg>) then
+end",
+}
+`;

--- a/src/__tests__/compilesb3.test.ts
+++ b/src/__tests__/compilesb3.test.ts
@@ -9,3 +9,10 @@ test("sb3 -> scratch-js", async () => {
 
   expect(project.toScratchJS()).toMatchSnapshot();
 });
+
+test("sb3 -> scratchblocks", async () => {
+  const file = fs.readFileSync(path.join(__dirname, "test.sb3"));
+  const project = await Project.fromSb3(file);
+
+  expect(project.toScratchblocks()).toMatchSnapshot();
+});

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -249,7 +249,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
         [OpCode.motion_pointtowards_menu]: { TOWARDS: "pointTowardsTarget" },
         [OpCode.motion_glideto_menu]: { TO: "goToTarget" },
         [OpCode.motion_goto_menu]: { TO: "goToTarget" },
-        [OpCode.motion_align_scene]: { ALIGNMENT: "string" }, // obsolete no-op so the value really doesn't matter
+        [OpCode.motion_align_scene]: { ALIGNMENT: "scrollAlignment" },
         [OpCode.looks_costume]: { COSTUME: "costume" },
         [OpCode.looks_gotofrontback]: { FRONT_BACK: "frontBackMenu" },
         [OpCode.looks_goforwardbackwardlayers]: { FORWARD_BACKWARD: "forwardBackwardMenu" },

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -266,7 +266,7 @@ export default function toScratchblocks(
       case OpCode.event_whenthisspriteclicked:
         return "when this sprite clicked";
       case OpCode.event_whenstageclicked:
-        return "when stage clicked";
+        return "when stage clicked :: control hat";
       case OpCode.event_whenbackdropswitchesto:
         return `when backdrop switches to ${i("BACKDROP", true)}`;
       case OpCode.event_whengreaterthan:

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -109,7 +109,7 @@ export default function toScratchblocks(
           return "\n" + indent(blockToScratchblocks(inp.value, target)) + "\n";
         } else {
           const ret: string = blockToScratchblocks(inp.value, target);
-          if (ret[0] === "(") {
+          if (ret[0] === "(" || ret[0] === "<") {
             return ret;
           } else {
             return "(" + ret + ")";

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -35,7 +35,7 @@ export default function toScratchblocks(
 
     switch (inp.type) {
       case "number":
-        if (typeof inp.value === "number") {
+        if (typeof inp.value === "number" || inp.value.trim().length === 0) {
           return `(${inp.value})`;
         } else {
           return `[${escape(inp.value)}]`;

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -303,7 +303,7 @@ export default function toScratchblocks(
       case OpCode.sensing_touchingcolor:
         return `<touching ${i("COLOR")} ?>`;
       case OpCode.sensing_coloristouchingcolor:
-        return `<${i("COLOR")} is touching ${i("COLOR2")} ?>`;
+        return `<color ${i("COLOR")} is touching ${i("COLOR2")} ?>`;
       case OpCode.sensing_distanceto:
         return `(distance to ${i("DISTANCETOMENU")})`;
       case OpCode.sensing_askandwait:

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -58,6 +58,17 @@ export default function toScratchblocks(
       case "costumeNumberName":
         return `[${escape(inp.value)} v]`;
 
+      case "goToTarget":
+      case "pointTowardsTarget":
+      case "cloneTarget": {
+        const value = {
+          "_mouse_": "mouse-pointer",
+          "_random_": "random position",
+          "_myself_": "myself"
+        }[inp.value] || inp.value;
+        return `(${escape(value)} v)`;
+      }
+
       case "costume":
       case "sound":
       case "goToTarget":

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -47,17 +47,23 @@ export default function toScratchblocks(
       case "string":
         return `[${escape(inp.value)}]`;
 
+      case "graphicEffect":
+      case "soundEffect":
+      case "currentMenu":
+      case "greaterThanMenu":
+        const value = {
+          "PAN": "pan left/right",
+          "DAYOFWEEK": "day of week"
+        }[inp.value] || inp.value.toLowerCase();
+        return `[${escape(value)} v]`;
+
       case "variable":
       case "list":
-      case "graphicEffect":
       case "rotationStyle":
       case "scrollAlignment":
-      case "soundEffect":
-      case "greaterThanMenu":
       case "stopMenu":
       case "dragModeMenu":
       case "propertyOfMenu":
-      case "currentMenu":
       case "mathopMenu":
       case "frontBackMenu":
       case "forwardBackwardMenu":
@@ -66,11 +72,14 @@ export default function toScratchblocks(
 
       case "goToTarget":
       case "pointTowardsTarget":
-      case "cloneTarget": {
+      case "cloneTarget":
+      case "distanceToMenu":
+      case "target": {
         const value = {
           "_mouse_": "mouse-pointer",
+          "_myself_": "myself",
           "_random_": "random position",
-          "_myself_": "myself"
+          "_stage_": "Stage"
         }[inp.value] || inp.value;
         return `(${escape(value)} v)`;
       }
@@ -88,7 +97,6 @@ export default function toScratchblocks(
       case "target":
       case "cloneTarget":
       case "touchingTarget":
-      case "distanceToMenu":
         return `(${escape(inp.value)} v)`;
 
       case "broadcast":

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -31,7 +31,7 @@ export default function toScratchblocks(
       return "";
     }
 
-    const escape = (value: string): string => value.replace(/[()\[\]]|v$/g, m => "\\" + m);
+    const escape = (value: string): string => (value || "").replace(/[()\[\]]|v$/g, m => "\\" + m);
 
     switch (inp.type) {
       case "number":
@@ -46,6 +46,7 @@ export default function toScratchblocks(
       case "graphicEffect":
       case "rotationStyle":
       case "scrollAlignment":
+      case "soundEffect":
       case "greaterThanMenu":
       case "stopMenu":
       case "dragModeMenu":
@@ -241,6 +242,8 @@ export default function toScratchblocks(
         return `when ${i("KEY_OPTION", true)} key pressed`;
       case OpCode.event_whenthisspriteclicked:
         return "when this sprite clicked";
+      case OpCode.event_whenstageclicked:
+        return "when stage clicked";
       case OpCode.event_whenbackdropswitchesto:
         return `when backdrop switches to ${i("BACKDROP", true)}`;
       case OpCode.event_whengreaterthan:
@@ -513,6 +516,30 @@ export default function toScratchblocks(
       case OpCode.videoSensing_setVideoTransparency:
         return `set video transparency to ${i("TRANSPARENCY")}`;
 
+        // leftover menu "blocks" ----------------------------------- //
+      case OpCode.motion_pointtowards_menu:
+      case OpCode.motion_glideto_menu:
+      case OpCode.motion_goto_menu:
+      case OpCode.looks_costume:
+      case OpCode.looks_backdrops:
+      case OpCode.sound_sounds_menu:
+      case OpCode.control_create_clone_of_menu:
+      case OpCode.sensing_touchingobjectmenu:
+      case OpCode.sensing_distancetomenu:
+      case OpCode.sensing_keyoptions:
+      case OpCode.sensing_of_object_menu:
+      case OpCode.pen_menu_colorParam:
+      case OpCode.music_menu_DRUM:
+      case OpCode.music_menu_INSTRUMENT:
+      case OpCode.videoSensing_menu_ATTRIBUTE:
+      case OpCode.videoSensing_menu_SUBJECT:
+      case OpCode.videoSensing_menu_VIDEO_STATE:
+      case OpCode.wedo2_menu_MOTOR_ID:
+      case OpCode.wedo2_menu_MOTOR_DIRECTION:
+      case OpCode.wedo2_menu_TILT_DIRECTION:
+      case OpCode.wedo2_menu_TILT_DIRECTION_ANY:
+        return "";
+
       default:
         return `unknown block [${block.opcode}] \\(${Object.keys(block.inputs)
           .map(k => `[${k}]`)
@@ -531,7 +558,10 @@ export default function toScratchblocks(
   const targets: { [targetName: string]: string } = {};
 
   for (const target of [project.stage, ...project.sprites]) {
-    targets[target.name] = target.scripts.map(script => scriptToScratchblocks(script, target)).join("\n\n");
+    targets[target.name] = target.scripts
+      .map(script => scriptToScratchblocks(script, target))
+      .filter(scratchblocks => scratchblocks.length > 0)
+      .join("\n\n");
   }
 
   return targets;

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -35,6 +35,12 @@ export default function toScratchblocks(
 
     switch (inp.type) {
       case "number":
+        if (typeof inp.value === "number") {
+          return `(${inp.value})`;
+        } else {
+          return `[${escape(inp.value)}]`;
+        }
+
       case "angle":
         return `(${inp.value})`;
 

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -131,7 +131,13 @@ export default function toScratchblocks(
 
     const i = (key: string, ...args): string => input(block.inputs[key], target, ...args);
     const operator = (op: string): string => `(${i("NUM1")} ${op} ${i("NUM2")})`;
-    const boolop = (op: string): string => `<${i("OPERAND1")} ${op} ${i("OPERAND2")}>`;
+    const boolop = (op: string, flag: boolean = false): string => {
+      if (flag) {
+        return `<${i("OPERAND1") || "<>"} ${op} ${i("OPERAND2") || "<>"}>`;
+      } else {
+        return `<${i("OPERAND1")} ${op} ${i("OPERAND2")}>`;
+      }
+    };
 
     switch (block.opcode) {
       // motion ------------------------------------------------------ //
@@ -374,9 +380,9 @@ export default function toScratchblocks(
       case OpCode.operator_equals:
         return boolop("=");
       case OpCode.operator_and:
-        return boolop("and");
+        return boolop("and", true);
       case OpCode.operator_or:
-        return boolop("or");
+        return boolop("or", true);
       case OpCode.operator_not:
         return `<not ${i("OPERAND") || "<>"}>`;
       case OpCode.operator_join:

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -1,0 +1,538 @@
+import Project from "../../Project";
+import Script from "../../Script";
+import Target from "../../Target";
+import Block from "../../Block";
+import * as BlockInput from "../../BlockInput";
+import { OpCode } from "../../OpCode";
+
+interface ToScratchblocksOptions {
+  indent: string;
+}
+
+export default function toScratchblocks(
+  options: Partial<ToScratchblocksOptions> = {}
+): { [targetName: string]: string } {
+  const project: Project = this;
+
+  const defaultOptions: ToScratchblocksOptions = {
+    indent: "\t"
+  };
+  options = { ...defaultOptions, ...options };
+
+  function indent(str: string): string {
+    return str
+      .split("\n")
+      .map(l => options.indent + l)
+      .join("\n");
+  }
+
+  function input(inp: BlockInput.Any, target: Target, flag: boolean = false): string {
+    if (!inp) {
+      return "";
+    }
+
+    const escape = (value: string): string => value.replace(/[()\[\]]|v$/g, m => "\\" + m);
+
+    switch (inp.type) {
+      case "number":
+      case "angle":
+        return `(${inp.value})`;
+
+      case "string":
+        return `[${escape(inp.value)}]`;
+
+      case "variable":
+      case "list":
+      case "graphicEffect":
+      case "rotationStyle":
+      case "scrollAlignment":
+      case "greaterThanMenu":
+      case "stopMenu":
+      case "dragModeMenu":
+      case "propertyOfMenu":
+      case "currentMenu":
+      case "mathopMenu":
+      case "frontBackMenu":
+      case "forwardBackwardMenu":
+      case "costumeNumberName":
+        return `[${escape(inp.value)} v]`;
+
+      case "costume":
+      case "sound":
+      case "goToTarget":
+      case "pointTowardsTarget":
+      case "penColorParam":
+      case "musicDrum":
+      case "musicInstrument":
+      case "videoSensingAttribute":
+      case "videoSensingSubject":
+      case "videoSensingVideoState":
+      case "target":
+      case "cloneTarget":
+      case "touchingTarget":
+      case "distanceToMenu":
+        return `(${escape(inp.value)} v)`;
+
+      case "broadcast":
+      case "backdrop":
+      case "key":
+        if (flag) {
+          return `[${escape(inp.value)} v]`;
+        } else {
+          return `(${escape(inp.value)} v)`;
+        }
+
+      case "color":
+        const hex = (k: string): string => inp.value[k].toString(16).padStart(2, "0");
+        return `[#${hex("r") + hex("g") + hex("b")}]`;
+
+      case "block":
+        if (flag) {
+          return "\n" + indent(blockToScratchblocks(inp.value, target)) + "\n";
+        } else {
+          const ret: string = blockToScratchblocks(inp.value, target);
+          if (ret[0] === "(") {
+            return ret;
+          } else {
+            return "(" + ret + ")";
+          }
+        }
+
+      case "blocks":
+        return "\n" + indent(blocksToScratchblocks(inp.value, target)) + "\n";
+
+      default:
+        return `(unknown input type [${inp.type}])`;
+    }
+  }
+
+  function blockToScratchblocks(block: Block, target: Target): string {
+    if (!target) {
+      throw new Error("expected target");
+    }
+
+    const i = (key: string, ...args): string => input(block.inputs[key], target, ...args);
+    const operator = (op: string): string => `(${i("NUM1")} ${op} ${i("NUM2")})`;
+    const boolop = (op: string): string => `<${i("OPERAND1")} ${op} ${i("OPERAND2")}>`;
+
+    switch (block.opcode) {
+      // motion ------------------------------------------------------ //
+      case OpCode.motion_movesteps:
+        return `move ${i("STEPS")} steps`;
+      case OpCode.motion_turnright:
+        return `turn cw ${i("DEGREES")} degrees`;
+      case OpCode.motion_turnleft:
+        return `turn ccw ${i("DEGREES")} degrees`;
+      case OpCode.motion_goto:
+        return `go to ${i("TO")}`;
+      case OpCode.motion_gotoxy:
+        return `go to x: ${i("X")} y: ${i("Y")}`;
+      case OpCode.motion_glideto:
+        return `glide ${i("SECS")} secs to ${i("TO")}`;
+      case OpCode.motion_glidesecstoxy:
+        return `glide ${i("SECS")} secs to x: ${i("X")} y: ${i("Y")}`;
+      case OpCode.motion_pointindirection:
+        return `point in direction ${i("DIRECTION")}`;
+      case OpCode.motion_pointtowards:
+        return `point towards ${i("TOWARDS")}`;
+      case OpCode.motion_changexby:
+        return `change x by ${i("DX")}`;
+      case OpCode.motion_setx:
+        return `set x to ${i("X")}`;
+      case OpCode.motion_changeyby:
+        return `change y by ${i("DY")}`;
+      case OpCode.motion_sety:
+        return `set y to ${i("Y")}`;
+      case OpCode.motion_ifonedgebounce:
+        return "if on edge, bounce";
+      case OpCode.motion_setrotationstyle:
+        return `set rotation style ${i("STYLE")}`;
+      case OpCode.motion_xposition:
+        return "(x position)";
+      case OpCode.motion_yposition:
+        return "(y position)";
+      case OpCode.motion_direction:
+        return "(direction)";
+      case OpCode.motion_scroll_right:
+        return `scroll right ${i("DISTANCE")} :: motion`;
+      case OpCode.motion_scroll_up:
+        return `scroll up ${i("DISTANCE")} :: motion`;
+      case OpCode.motion_align_scene:
+        return `align scene ${i("ALIGNMENT")} :: motion`;
+      case OpCode.motion_xscroll:
+        return `(x scroll)`;
+      case OpCode.motion_yscroll:
+        return `(y scroll)`;
+
+      // looks ------------------------------------------------------- //
+      case OpCode.looks_sayforsecs:
+        return `say ${i("MESSAGE")} for ${i("SECS")} seconds`;
+      case OpCode.looks_say:
+        return `say ${i("MESSAGE")}`;
+      case OpCode.looks_thinkforsecs:
+        return `think ${i("MESSAGE")} for ${i("SECS")} seconds`;
+      case OpCode.looks_think:
+        return `think ${i("MESSAGE")}`;
+      case OpCode.looks_switchcostumeto:
+        return `switch costume to ${i("COSTUME")}`;
+      case OpCode.looks_nextcostume:
+        return "next costume";
+      case OpCode.looks_switchbackdropto:
+        return `switch backdrop to ${i("BACKDROP")}`;
+      case OpCode.looks_nextbackdrop:
+        return `next backdrop`;
+      case OpCode.looks_changesizeby:
+        return `change size by ${i("CHANGE")}`;
+      case OpCode.looks_setsizeto:
+        return `set size to ${i("SIZE")}%`;
+      case OpCode.looks_changeeffectby:
+        return `change ${i("EFFECT")} effect by ${i("CHANGE")} :: looks`;
+      case OpCode.looks_seteffectto:
+        return `set ${i("EFFECT")} effect to ${i("VALUE")} :: looks`;
+      case OpCode.looks_cleargraphiceffects:
+        return "clear graphic effects";
+      case OpCode.looks_show:
+        return "show";
+      case OpCode.looks_hide:
+        return "hide";
+      case OpCode.looks_gotofrontback:
+        return `go to ${i("FRONT_BACK")} layer`;
+      case OpCode.looks_goforwardbackwardlayers:
+        return `go ${i("FORWARD_BACKWARD")} ${i("NUM")} layers`;
+      case OpCode.looks_costumenumbername:
+        return `(costume ${i("NUMBER_NAME")})`;
+      case OpCode.looks_backdropnumbername:
+        return `(backdrop ${i("NUMBER_NAME")})`;
+      case OpCode.looks_size:
+        return "(size)";
+      case OpCode.looks_hideallsprites:
+        return "hide all sprites :: looks";
+      case OpCode.looks_switchbackdroptoandwait:
+        return `switch backdrop to ${i("BACKDROP")} and wait`;
+      case OpCode.looks_changestretchby:
+        return `change stretch by ${i("CHANGE")} :: looks`;
+      case OpCode.looks_setstretchto:
+        return `set stretch to ${i("STRETCH")} % :: looks`;
+
+      // sound ------------------------------------------------------- //
+      case OpCode.sound_playuntildone:
+        return `play sound ${i("SOUND_MENU")} until done`;
+      case OpCode.sound_play:
+        return `start sound ${i("SOUND_MENU")}`;
+      case OpCode.sound_stopallsounds:
+        return "stop all sounds";
+      case OpCode.sound_changeeffectby:
+        return `change ${i("EFFECT")} effect by ${i("VALUE")} :: sound`;
+      case OpCode.sound_seteffectto:
+        return `set ${i("EFFECT")} effect to ${i("VALUE")} :: sound`;
+      case OpCode.sound_cleareffects:
+        return "clear sound effects";
+      case OpCode.sound_changevolumeby:
+        return `change volume by ${i("VOLUME")}`;
+      case OpCode.sound_setvolumeto:
+        return `set volume to ${i("VOLUME")} %`;
+      case OpCode.sound_volume:
+        return "(volume)";
+
+      // events ------------------------------------------------------ //
+      case OpCode.event_whenflagclicked:
+        return "when green flag clicked";
+      case OpCode.event_whenkeypressed:
+        return `when ${i("KEY_OPTION", true)} key pressed`;
+      case OpCode.event_whenthisspriteclicked:
+        return "when this sprite clicked";
+      case OpCode.event_whenbackdropswitchesto:
+        return `when backdrop switches to ${i("BACKDROP", true)}`;
+      case OpCode.event_whengreaterthan:
+        return `when ${i("WHENGREATERTHANMENU")} > ${i("VALUE")}`;
+      case OpCode.event_whenbroadcastreceived:
+        return `when I receive ${i("BROADCAST_OPTION", true)}`;
+      case OpCode.event_broadcast:
+        return `broadcast ${i("BROADCAST_INPUT")}`;
+      case OpCode.event_broadcastandwait:
+        return `broadcast ${i("BROADCAST_INPUT")} and wait`;
+
+      // control ----------------------------------------------------- //
+      case OpCode.control_wait:
+        return `wait ${i("DURATION")} seconds`;
+      case OpCode.control_repeat:
+        return `repeat ${i("TIMES")}` + (i("SUBSTACK", true) || "\n") + "end";
+      case OpCode.control_forever:
+        return "forever" + (i("SUBSTACK", true) || "\n") + "end";
+      case OpCode.control_if:
+        return `if ${i("CONDITION") || "<>"} then` + (i("SUBSTACK", true) || "\n") + "end";
+      case OpCode.control_if_else:
+        return (
+          `if ${i("CONDITION") || "<>"} then` +
+          (i("SUBSTACK", true) || "\n") +
+          "else" +
+          (i("SUBSTACK2", true) || "\n") +
+          "end"
+        );
+      case OpCode.control_wait_until:
+        return `wait until ${i("CONDITION") || "<>"}`;
+      case OpCode.control_repeat_until:
+        return `repeat until ${i("CONDITION") || "<>"}` + (i("SUBSTACK", true) || "\n") + "end";
+      case OpCode.control_while:
+        return `while ${i("CONDITION") || "<>"} {` + (i("SUBSTACK", true) || "\n") + "} :: control";
+      case OpCode.control_for_each:
+        return `for each ${i("VARIABLE")} in ${i("VALUE")} {` + (i("SUBSTACK", true) || "\n") + "} :: control";
+      case OpCode.control_all_at_once:
+        return `all at once {` + (i("SUBSTACK", true) || "\n") + `} :: control`;
+      case OpCode.control_stop:
+        return `stop ${i("STOP_OPTION")}`;
+      case OpCode.control_start_as_clone:
+        return "when I start as a clone";
+      case OpCode.control_create_clone_of:
+        return `create clone of ${i("CLONE_OPTION")}`;
+      case OpCode.control_delete_this_clone:
+        return "delete this clone";
+      case OpCode.control_get_counter:
+        return `(counter :: control)`;
+      case OpCode.control_incr_counter:
+        return `increment counter :: control`;
+      case OpCode.control_clear_counter:
+        return `clear coutner :: control`;
+
+      // sensing ----------------------------------------------------- //
+      case OpCode.sensing_touchingobject:
+        return `<touching ${i("TOUCHINGOBJECTMENU")} ?>`;
+      case OpCode.sensing_touchingcolor:
+        return `<touching ${i("COLOR")} ?>`;
+      case OpCode.sensing_coloristouchingcolor:
+        return `<${i("COLOR")} is touching ${i("COLOR2")} ?>`;
+      case OpCode.sensing_distanceto:
+        return `(distance to ${i("DISTANCETOMENU")})`;
+      case OpCode.sensing_askandwait:
+        return `ask ${i("QUESTION")} and wait`;
+      case OpCode.sensing_answer:
+        return "(answer)";
+      case OpCode.sensing_keypressed:
+        return `<key ${i("KEY_OPTION")} pressed?>`;
+      case OpCode.sensing_mousedown:
+        return "<mouse down?>";
+      case OpCode.sensing_mousex:
+        return "(mouse x)";
+      case OpCode.sensing_mousey:
+        return "(mouse y)";
+      case OpCode.sensing_setdragmode:
+        return `set drag mode ${i("DRAG_MODE")}`;
+      case OpCode.sensing_loudness:
+        return "(loudness)";
+      case OpCode.sensing_loud:
+        return "<loud? :: sensing>";
+      case OpCode.sensing_timer:
+        return "(timer)";
+      case OpCode.sensing_resettimer:
+        return "reset timer";
+      case OpCode.sensing_of:
+        return `(${i("PROPERTY")} of ${i("OBJECT")})`;
+      case OpCode.sensing_current:
+        return `(current ${i("CURRENTMENU")})`;
+      case OpCode.sensing_dayssince2000:
+        return "(days since 2000)";
+      case OpCode.sensing_username:
+        return "(username)";
+      case OpCode.sensing_userid:
+        return "(user id :: sensing)";
+
+      // operators --------------------------------------------------- //
+      case OpCode.operator_add:
+        return operator("+");
+      case OpCode.operator_subtract:
+        return operator("-");
+      case OpCode.operator_multiply:
+        return operator("*");
+      case OpCode.operator_divide:
+        return operator("/");
+      case OpCode.operator_random:
+        return `(pick random ${i("FROM")} to ${i("TO")})`;
+      case OpCode.operator_gt:
+        return boolop(">");
+      case OpCode.operator_lt:
+        return boolop("<");
+      case OpCode.operator_equals:
+        return boolop("=");
+      case OpCode.operator_and:
+        return boolop("and");
+      case OpCode.operator_or:
+        return boolop("or");
+      case OpCode.operator_not:
+        return `<not ${i("OPERAND") || "<>"}>`;
+      case OpCode.operator_join:
+        return `(join ${i("STRING1")} ${i("STRING2")})`;
+      case OpCode.operator_letter_of:
+        return `(letter ${i("LETTER")} of ${i("STRING")})`;
+      case OpCode.operator_length:
+        return `(length of ${i("STRING")})`;
+      case OpCode.operator_contains:
+        return `<${i("STRING1")} contains ${i("STRING2")} ? :: operators>`;
+      case OpCode.operator_mod:
+        return operator("mod");
+      case OpCode.operator_round:
+        return `(round ${i("NUM")})`;
+      case OpCode.operator_mathop:
+        return `(${i("OPERATOR")} of ${i("NUM")})`;
+
+      // data -------------------------------------------------------- //
+      case OpCode.data_variable:
+        return `(${block.inputs.VARIABLE.value} :: variables)`;
+      case OpCode.data_setvariableto:
+        return `set ${i("VARIABLE")} to ${i("VALUE")}`;
+      case OpCode.data_changevariableby:
+        return `change ${i("VARIABLE")} by ${i("VALUE")}`;
+      case OpCode.data_showvariable:
+        return `show variable ${i("VARIABLE")}`;
+      case OpCode.data_hidevariable:
+        return `hide variable ${i("VARIABLE")}`;
+      case OpCode.data_listcontents:
+        return `(${block.inputs.LIST.value} :: list)`;
+      case OpCode.data_addtolist:
+        return `add ${i("ITEM")} to ${i("LIST")}`;
+      case OpCode.data_deleteoflist:
+        return `delete ${i("INDEX")} of ${i("LIST")}`;
+      case OpCode.data_deletealloflist:
+        return `delete all of ${i("LIST")}`;
+      case OpCode.data_insertatlist:
+        return `insert ${i("ITEM")} at ${i("INDEX")} of ${i("LIST")}`;
+      case OpCode.data_replaceitemoflist:
+        return `replace item ${i("INDEX")} of ${i("LIST")} with ${i("ITEM")}`;
+      case OpCode.data_itemoflist:
+        return `(item ${i("INDEX")} of ${i("LIST")})`;
+      case OpCode.data_itemnumoflist:
+        return `(item # of ${i("ITEM")} in ${i("LIST")})`;
+      case OpCode.data_lengthoflist:
+        return `(length of ${i("LIST")})`;
+      case OpCode.data_listcontainsitem:
+        return `<${i("LIST")} contains ${i("ITEM")} ? :: list>`;
+      case OpCode.data_showlist:
+        return `show list ${i("LIST")}`;
+      case OpCode.data_hidelist:
+        return `hide list ${i("LIST")}`;
+
+      // custom blocks ----------------------------------------------- //
+      case OpCode.procedures_definition:
+        const spec = block.inputs.ARGUMENTS.value
+          .map(({ type, name }) => {
+            switch (type) {
+              case "label":
+                return name.replace(/\//g, "\\/");
+              case "numberOrString":
+                return `(${name})`;
+              case "boolean":
+                return `<${name}>`;
+            }
+          })
+          .join(" ");
+        return `define ${spec}` + (block.inputs.WARP.value ? " // run without screen refresh" : "");
+      case OpCode.procedures_call:
+        const definition = target.scripts
+          .map(s => s.blocks[0])
+          .find(
+            b => b.opcode === OpCode.procedures_definition && b.inputs.PROCCODE.value === block.inputs.PROCCODE.value
+          );
+        // we guarantee the opcode check is true already by checking it in find(), but typescript doesn't seem to notice that, so we include this assert here
+        if (definition && definition.opcode === OpCode.procedures_definition) {
+          let index = 0;
+          return (
+            definition.inputs.ARGUMENTS.value
+              .map(({ type, name }) => {
+                switch (type) {
+                  case "label":
+                    return name.replace(/\//g, "\\/");
+                  default:
+                    // TODO: deal with empty boolean inputs, which can't even load yet
+                    return input(block.inputs.INPUTS.value[index++], target);
+                }
+              })
+              .join(" ") + " :: custom"
+          );
+        } else {
+          return `... // missing custom block definition for ${block.inputs.PROCCODE.value}`;
+        }
+      case OpCode.argument_reporter_string_number:
+        return `(${block.inputs.VALUE.value} :: custom-arg)`;
+      case OpCode.argument_reporter_boolean:
+        return `<${block.inputs.VALUE.value} :: custom-arg>`;
+
+      // extension: music -------------------------------------------- //
+      case OpCode.music_playDrumForBeats:
+        return `play drum ${i("DRUM")} for ${i("BEATS")} beats`;
+      case OpCode.music_midiPlayDrumForBeats:
+        return `play (old midi) drum ${i("DRUM")} for ${i("BEATS")} beats :: music`;
+      case OpCode.music_restForBeats:
+        return `rest for ${i("BEATS")} beats`;
+      case OpCode.music_playNoteForBeats:
+        return `play note ${i("NOTE")} for ${i("BEATS")} beats`;
+      case OpCode.music_setInstrument:
+        return `set instrument to ${i("INSTRUMENT")}`;
+      case OpCode.music_midiSetInstrument:
+        return `set (old midi) instrument to ${i("INSTRUENT")} :: music`;
+      case OpCode.music_setTempo:
+        return `set tempo to ${i("TEMPO")}`;
+      case OpCode.music_changeTempo:
+        return `change tempo by ${i("TEMPO")}`;
+      case OpCode.music_getTempo:
+        return `(tempo)`;
+
+      // extension: pen ---------------------------------------------- //
+      case OpCode.pen_clear:
+        return "erase all";
+      case OpCode.pen_stamp:
+        return "stamp";
+      case OpCode.pen_penDown:
+        return "pen down";
+      case OpCode.pen_penUp:
+        return "pen up";
+      case OpCode.pen_setPenColorToColor:
+        return `set pen color to ${i("COLOR")}`;
+      case OpCode.pen_changePenColorParamBy:
+        return `change pen ${i("COLOR_PARAM")} by ${i("VALUE")}`;
+      case OpCode.pen_setPenColorParamTo:
+        return `set pen ${i("COLOR_PARAM")} to ${i("VALUE")}`;
+      case OpCode.pen_changePenSizeBy:
+        return `change pen size by ${i("SIZE")}`;
+      case OpCode.pen_setPenSizeTo:
+        return `set pen size to ${i("SIZE")}`;
+      case OpCode.pen_changePenShadeBy:
+        return `change pen shade by ${i("SHADE")}`;
+      case OpCode.pen_setPenShadeToNumber:
+        return `set pen shade to ${i("SHADE")}`;
+      case OpCode.pen_changePenHueBy:
+        return `change pen color by ${i("HUE")}`;
+      case OpCode.pen_setPenHueToNumber:
+        return `set pen hue to ${i("HUE")}`;
+
+      // extension: video sensing ----------------------------------- //
+      case OpCode.videoSensing_whenMotionGreaterThan:
+        return `when video motion > ${i("REFERENCE")}`;
+      case OpCode.videoSensing_videoOn:
+        return `(video ${i("ATTRIBUTE")} on ${i("SUBJECT")})`;
+      case OpCode.videoSensing_videoToggle:
+        return `turn video ${i("VIDEO_STATE")}`;
+      case OpCode.videoSensing_setVideoTransparency:
+        return `set video transparency to ${i("TRANSPARENCY")}`;
+
+      default:
+        return `unknown block [${block.opcode}] \\(${Object.keys(block.inputs)
+          .map(k => `[${k}]`)
+          .join(", ")}\\)`;
+    }
+  }
+
+  function blocksToScratchblocks(blocks: Block[], target: Target): string {
+    return blocks.map(b => blockToScratchblocks(b, target)).join("\n");
+  }
+
+  function scriptToScratchblocks(script: Script, target: Target): string {
+    return blocksToScratchblocks(script.blocks, target);
+  }
+
+  const targets: { [targetName: string]: string } = {};
+
+  for (const target of [project.stage, ...project.sprites]) {
+    targets[target.name] = target.scripts.map(script => scriptToScratchblocks(script, target)).join("\n\n");
+  }
+
+  return targets;
+}

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -74,6 +74,7 @@ export default function toScratchblocks(
       case "pointTowardsTarget":
       case "cloneTarget":
       case "distanceToMenu":
+      case "touchingTarget":
       case "target": {
         const value = {
           "_mouse_": "mouse-pointer",
@@ -86,17 +87,12 @@ export default function toScratchblocks(
 
       case "costume":
       case "sound":
-      case "goToTarget":
-      case "pointTowardsTarget":
       case "penColorParam":
       case "musicDrum":
       case "musicInstrument":
       case "videoSensingAttribute":
       case "videoSensingSubject":
       case "videoSensingVideoState":
-      case "target":
-      case "cloneTarget":
-      case "touchingTarget":
         return `(${escape(inp.value)} v)`;
 
       case "broadcast":


### PR DESCRIPTION
This PR adds an IO file for exporting to the [scratchblocks](https://scratchblocks.github.io/) format, used [on the official Scratch discussion forums](https://scratch.mit.edu/discuss/) and [as a web-embeddable library](https://github.com/scratchblocks/scratchblocks#usage). It resolves #11.

The new API is `(project).toScratchblocks`, returning an object `{[targetName]: "when green flag clicked..."}`.

Changes in this PR depend on #12, #13, and #16. Those should all be merged prior to this.