### PR TITLE
Implement event_whenstageclicked block

### DIFF
--- a/src/Block.ts
+++ b/src/Block.ts
@@ -38,6 +38,7 @@ export class BlockBase<MyOpCode extends OpCode, MyInputs extends { [key: string]
       OpCode.event_whenflagclicked,
       OpCode.event_whenkeypressed,
       OpCode.event_whenthisspriteclicked,
+      OpCode.event_whenstageclicked,
       OpCode.event_whenbackdropswitchesto,
       OpCode.event_whengreaterthan,
       OpCode.event_whenbroadcastreceived,
@@ -113,6 +114,7 @@ export type KnownBlock =
   | BlockBase<OpCode.event_whenflagclicked, {}>
   | BlockBase<OpCode.event_whenkeypressed, { KEY_OPTION: BlockInput.Key }>
   | BlockBase<OpCode.event_whenthisspriteclicked, {}>
+  | BlockBase<OpCode.event_whenstageclicked, {}>
   | BlockBase<OpCode.event_whenbackdropswitchesto, { BACKDROP: BlockInput.Backdrop }>
   | BlockBase<
       OpCode.event_whengreaterthan,

--- a/src/OpCode.ts
+++ b/src/OpCode.ts
@@ -55,6 +55,7 @@ export enum OpCode {
   event_whenflagclicked = "event_whenflagclicked",
   event_whenkeypressed = "event_whenkeypressed",
   event_whenthisspriteclicked = "event_whenthisspriteclicked",
+  event_whenstageclicked = "event_whenstageclicked",
   event_whenbackdropswitchesto = "event_whenbackdropswitchesto",
   event_whengreaterthan = "event_whengreaterthan",
   event_whenbroadcastreceived = "event_whenbroadcastreceived",

--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -77,6 +77,7 @@ export default class Stage extends StageBase {
         { key: \\"space\\" },
         this.whenKeySpacePressed
       ),
+      new Trigger(Trigger.CLICKED, this.whenstageclicked),
       new Trigger(
         Trigger.BROADCAST,
         { name: \\"message1\\" },
@@ -107,6 +108,28 @@ export default class Stage extends StageBase {
     /* TODO: Implement sound_cleareffects */ null;
     /* TODO: Implement sound_changevolumeby */ null;
     /* TODO: Implement sound_setvolumeto */ null;
+  }
+
+  *whenstageclicked() {
+    yield* this.askAndWait(\\"What's your name?\\");
+    yield* this.askAndWait(this.answer);
+    yield* this.askAndWait(this.keyPressed(\\"space\\"));
+    yield* this.askAndWait(this.mouse.down);
+    yield* this.askAndWait(this.mouse.x);
+    yield* this.askAndWait(this.mouse.y);
+    yield* this.askAndWait(/* TODO: Implement sensing_loudness */ null);
+    yield* this.askAndWait(this.timer);
+    yield* this.askAndWait(this.stage.costumeNumber);
+    yield* this.askAndWait(this.stage.vars[\\"CloudVar\\"]);
+    yield* this.askAndWait(new Date().getDay() + 1);
+    yield* this.askAndWait(
+      ((new Date().getTime() - new Date(2000, 0, 1)) / 1000 / 60 +
+        new Date().getTimezoneOffset()) /
+        60 /
+        24
+    );
+    yield* this.askAndWait(/* no username */ \\"\\");
+    this.restartTimer();
   }
 
   *whenbackdropswitchesto() {

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -23,6 +23,7 @@ function triggerInitCode(script: Script) {
     case OpCode.event_whenkeypressed:
       return triggerInitStr("KEY_PRESSED", { key: hat.inputs.KEY_OPTION.value });
     case OpCode.event_whenthisspriteclicked:
+    case OpCode.event_whenstageclicked:
       return triggerInitStr("CLICKED");
     case OpCode.event_whenbroadcastreceived:
       return triggerInitStr("BROADCAST", { name: hat.inputs.BROADCAST_OPTION.value });


### PR DESCRIPTION
Turns out this block was missing from the library! I double-checked all the other opcodes I saw listed in scratch-vm and this was the only one missing (besides `event_whentouchingobject`, which was [implemented](https://github.com/LLK/scratch-gui/pull/2265) but hasn't yet been released because of [related issues](https://github.com/LLK/scratch-vm/issues/1532) - I figure we don't need to do anything with that until it's officially released).

The test.sb3 project actually had a "when stage clicked" block in it which thanks to this wasn't showing up in the snapshot, so I updated that. (The snapshot is actually how I spotted this missing block - an `unknown block [event_whenstageclicked]` message in the scratchblocks snapshot, while debugging.)

This must be merged prior to #15.