### PR TITLE
Support dynamic costume switching

### DIFF
--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -14,10 +14,10 @@ export default class Abby extends Sprite {
     super(...args);
 
     this.costumes = [
-      new Costume(\\"abbyA\\", \\"./Abby/costumes/abbyA.svg\\", { x: 31, y: 100 }),
-      new Costume(\\"abbyB\\", \\"./Abby/costumes/abbyB.svg\\", { x: 31, y: 100 }),
-      new Costume(\\"abbyC\\", \\"./Abby/costumes/abbyC.svg\\", { x: 32, y: 100 }),
-      new Costume(\\"abbyD\\", \\"./Abby/costumes/abbyD.svg\\", { x: 32, y: 101 })
+      new Costume(\\"abby-a\\", \\"./Abby/costumes/abby-a.svg\\", { x: 31, y: 100 }),
+      new Costume(\\"abby-b\\", \\"./Abby/costumes/abby-b.svg\\", { x: 31, y: 100 }),
+      new Costume(\\"abby-c\\", \\"./Abby/costumes/abby-c.svg\\", { x: 32, y: 100 }),
+      new Costume(\\"abby-d\\", \\"./Abby/costumes/abby-d.svg\\", { x: 32, y: 101 })
     ];
 
     this.triggers = [
@@ -93,7 +93,7 @@ export default class Stage extends StageBase {
   *whenGreenFlagClicked() {
     this.costume = \\"backdrop1\\";
     /* TODO: Implement looks_switchbackdroptoandwait */ null;
-    this.costume += 1;
+    this.costumeNumber += 1;
     this.effects.color += this.costumeNumber;
     this.effects.color = this.costume.name;
     this.effects.clear();

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -125,23 +125,11 @@ export default function toScratchJS(
   let targetNameMap = {};
   let customBlockArgNameMap: Map<Script, { [key: string]: string }> = new Map();
   let variableNameMap: Map<Target, { [key: string]: string }> = new Map();
-  let costumeNameMap: Map<Target, { [key: string]: string }> = new Map();
 
   for (const target of [project.stage, ...project.sprites]) {
     const newTargetName = uniqueName(camelCase(target.name, true));
     targetNameMap[target.name] = newTargetName;
     target.setName(newTargetName);
-
-    const uniqueCostumeName = uniqueNameGenerator();
-
-    const cNameMap = {};
-    costumeNameMap.set(target, cNameMap);
-
-    for (const costume of target.costumes) {
-      const newName = uniqueCostumeName(camelCase(costume.name));
-      cNameMap[costume.name] = newName;
-      costume.setName(newName);
-    }
 
     const uniqueSoundName = uniqueNameGenerator();
     for (const sound of target.sounds) {
@@ -366,16 +354,13 @@ export default function toScratchJS(
         case OpCode.looks_think:
           return `this.think(${inputToJS(block.inputs.MESSAGE)})`;
         case OpCode.looks_switchcostumeto:
-          return `this.costume = (${JSON.stringify(costumeNameMap.get(target)[block.inputs.COSTUME.value])})`;
+          return `this.costume = (${inputToJS(block.inputs.COSTUME)})`;
         case OpCode.looks_nextcostume:
           return `this.costumeNumber += 1`;
         case OpCode.looks_switchbackdropto:
-          // TODO: Next backdrop, previous backdrop, etc...
-          return `${stage}.costume = (${JSON.stringify(
-            costumeNameMap.get(project.stage)[block.inputs.BACKDROP.value]
-          )})`;
+          return `${stage}.costume = (${inputToJS(block.inputs.BACKDROP)})`;
         case OpCode.looks_nextbackdrop:
-          return `${stage}.costume += 1`;
+          return `${stage}.costumeNumber += 1`;
         case OpCode.looks_changesizeby:
           return `this.size += (${inputToJS(block.inputs.CHANGE)})`;
         case OpCode.looks_setsizeto:


### PR DESCRIPTION
I.e, support reporters in the switch-costume and switch-backdrop blocks.

This removes the "unique costume name" code which fundamentally prevents dyanmic costume switching, since it renames costumes in ways the project source code generally doesn't expect.

@PullJosh since you wrote that code originally, do you think this is a safe change? I don't understand its original purpose myself, so I just replaced it with this simpler code.

This makes PullJosh/scratch-js#45 have effect—without this PR, scripts such as "switch costume to (any reporter)" just get converted to `this.costume = undefined`—but the two PRs are totally independent of each other, merging-wise.