### PR TITLE
scratch-js: support dynamic sounds & sound objects

### DIFF
--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -6,7 +6,8 @@ Object {
   Sprite,
   Trigger,
   Costume,
-  Color
+  Color,
+  Sound
 } from \\"https://pulljosh.github.io/scratch-js/scratch-js/index.mjs\\";
 
 export default class Abby extends Sprite {
@@ -19,6 +20,8 @@ export default class Abby extends Sprite {
       new Costume(\\"abby-c\\", \\"./Abby/costumes/abby-c.svg\\", { x: 32, y: 100 }),
       new Costume(\\"abby-d\\", \\"./Abby/costumes/abby-d.svg\\", { x: 32, y: 101 })
     ];
+
+    this.sounds = [new Sound(\\"pop\\", \\"./Abby/sounds/pop.wav\\")];
 
     this.triggers = [
       new Trigger(Trigger.CLONE_START, this.startAsClone),
@@ -56,7 +59,8 @@ export default class Abby extends Sprite {
   Stage as StageBase,
   Trigger,
   Costume,
-  Color
+  Color,
+  Sound
 } from \\"https://pulljosh.github.io/scratch-js/scratch-js/index.mjs\\";
 
 export default class Stage extends StageBase {
@@ -69,6 +73,8 @@ export default class Stage extends StageBase {
         y: 180
       })
     ];
+
+    this.sounds = [new Sound(\\"pop\\", \\"./Stage/sounds/pop.wav\\")];
 
     this.triggers = [
       new Trigger(Trigger.GREEN_FLAG, this.whenGreenFlagClicked),
@@ -100,8 +106,8 @@ export default class Stage extends StageBase {
   }
 
   *whenKeySpacePressed() {
-    yield* this.playSound(/* TODO: Get url for sound [object Object] */);
-    this.playSound(/* TODO: Get url for sound [object Object] */);
+    yield* this.playSoundUntilDone(\\"pop\\");
+    this.startSound(\\"pop\\");
     this.stopAllSounds();
     /* TODO: Implement sound_changeeffectby */ null;
     /* TODO: Implement sound_seteffectto */ null;
@@ -201,7 +207,7 @@ export default class Stage extends StageBase {
   }
 
   *blockNameLabelText(boolean, numberOrText) {
-    yield* this.playSound(/* TODO: Get url for sound [object Object] */);
+    yield* this.playSoundUntilDone(numberOrText);
     if (boolean) {
       null;
     }


### PR DESCRIPTION
As corresponding to #17, this PR removes the code which transformed costume names, since we always refer to sounds by string-style accessing anyway (`getSoundByName`, `startSound`, etc). This enables accessing sounds dynamically, e.g. "play sound (pick random 0 to 4)". It also implements the code for `sound_playuntildone` and `sound_playsound` (the same way that PR does).

This should be merged after PullJosh/scratch-js#49, since it stores sounds on the new `target.sounds` property implemented there.

/cc @PullJosh - btw, do you think we should start organizing PRs and commits with prefixes like "scratch-js: ..." or "scratchblocks: ..."? It would help for reading/searching through commits and PRs, and makes it more obvious what's referring to what.