### PR TITLE
License under MIT instead of ISC, and update package.json to match scratch-js

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,9 @@
+Copyright (c) 2020, Josh Pullen <hello@joshuapullen.com>
+Copyright (c) 2020, Florrie Haero Miller <towerofnix@gmail.com>
+Copyright (c) 2020, adroitwhiz <adroitwhiz@protonmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "sb3",
     "scratch-js"
   ],
-  "author": {
-    "name": "Josh Pullen",
-    "email": "hello@joshuapullen.com",
-    "url": "https://joshuapullen.com/"
+  "author": "Josh Pullen <hello@joshuapullen.com> (https://joshuapullen.com/)",
+  "contributors": {
+    "Florrie Haero Miller <towerofnix@gmail.com> (https://github.com/towerofnix)",
+    "adroitwhiz <adroitwhiz@protonmail.com> (https://github.com/adroitwhiz)"
   },
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.22",
     "@types/jszip": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "scratch-js"
   ],
   "author": "Josh Pullen <hello@joshuapullen.com> (https://joshuapullen.com/)",
-  "contributors": {
+  "contributors": [
     "Florrie Haero Miller <towerofnix@gmail.com> (https://github.com/towerofnix)",
     "adroitwhiz <adroitwhiz@protonmail.com> (https://github.com/adroitwhiz)"
-  },
+  ],
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.22",


### PR DESCRIPTION
Same deal as PullJosh/scratch-js#50, though here we're changing the license from ISC to MIT, to keep things consistent across libraries.