### PR TITLE
scratch-js: yield from startSound()

### DIFF
--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -107,7 +107,7 @@ export default class Stage extends StageBase {
 
   *whenKeySpacePressed() {
     yield* this.playSoundUntilDone(\\"pop\\");
-    this.startSound(\\"pop\\");
+    yield* this.startSound(\\"pop\\");
     this.stopAllSounds();
     /* TODO: Implement sound_changeeffectby */ null;
     /* TODO: Implement sound_seteffectto */ null;

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -400,7 +400,7 @@ export default function toScratchJS(
         case OpCode.sound_playuntildone:
           return `yield* this.playSoundUntilDone(${inputToJS(block.inputs.SOUND_MENU)})`;
         case OpCode.sound_play:
-          return `this.startSound(${inputToJS(block.inputs.SOUND_MENU)})`;
+          return `yield* this.startSound(${inputToJS(block.inputs.SOUND_MENU)})`;
         case OpCode.sound_stopallsounds:
           return `this.stopAllSounds()`;
         case OpCode.event_broadcast:


### PR DESCRIPTION
Should be merged alongside PullJosh/scratch-js#52, which makes `startSound` into a generator. `startSound` now waits for the specified sound to be completely downloaded and started before continuing to the following code. (`playSoundUntilDone` must still be used to wait for the sound to finish playing as well.)