### PR TITLE
sb3: load volume correctly for sprites

### DIFF
--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -456,7 +456,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: ge
                 ),
               variables: getVariables(spriteData),
               lists: getLists(spriteData),
-              volume: stage.volume,
+              volume: spriteData.volume,
               layerOrder: spriteData.layerOrder,
               x: spriteData.x,
               y: spriteData.y,


### PR DESCRIPTION
Sprites currently inherit their audio volume from the stage, instead of having their own distinct volume, like they're supposed to. This PR fixes that.