### PR TITLE
sb3: don't import top-level shadow blocks

### DIFF
--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -446,6 +446,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: ge
               sounds: await extractSounds(spriteData, options.getAsset),
               scripts: Object.entries(spriteData.blocks)
                 .filter(([id, block]) => block.topLevel)
+                .filter(([id, block]) => !block.shadow)
                 .map(
                   ([id, block]) =>
                     new Script({


### PR DESCRIPTION
This PR prevents top-level shadow blocks from being imported into an sb-edit project.

**What are top-level shadow blocks?**

*Shadow blocks* represent any reporter-accepting slot in a Scratch 3.0 block. There are two kinds of shadow blocks: *primitive* and *non-primitive*. Primitive shadow blocks are stored as a simple `[primitiveType, value]` array under a block's `inputs` field; these aren't what we're concerned with here.

What we care about are *non-primitive* shadow blocks. These are stored in much the same way as ordinary blocks - i.e, as entries on a target's `blocks` field. They're distinguishable from normal blocks by their `"shadow": true` property.

(Note: "primitive" and "non-primitive" are only terms that exist within (de)serialization of Scratch 3.0 projects. Other parts of the VM and scratch-blocks only see them as ordinary, i.e. non-primitive, shadow blocks.)

Most dropdown menus which accept blocks in Scratch 3.0 are stored as non-primitive shadow blocks. When you drop a block into a block slot, you are *obscuring* the shadow block—the actual (text, number, menu, etc) input—that occupies that slot.

![The block "join (costume) (2)", held up over the menu input in "switch costume to (costume2)".](https://user-images.githubusercontent.com/9948030/74673460-9aedd700-5185-11ea-9fcc-eb3fe0c7d736.png)

It's important to note that Scratch 3.0 introduced a new quality of life feature: when a block is dropped into an input slot, if you remove the block later, the original value entered into that input will be restored. The technical implementation of this was to have two types of input values pertaining to shadows: *obscured* and *non-obscured* (or, in VM terms, "shadow different from block" and "shadow same as block"). When an input's shadow has been obscured, the VM serializes the shadow block beside the ID to the obscuring block. Removing the block simply meant restoring the obscured shadow.

For *primitive* obscured shadow blocks, their `[primitiveType, value]` array is simply stored adjacent to the ID of the obscuring block, whereas non-primitive shadow blocks, as always, are stored within a block's `inputs` field as their ID strings - adjacent to the ID of the block, when obscured, like primitives.

However, **due to a quirk in Scratch 3.0,** obscured non-primitive shadow blocks have the flag `{"topLevel": true}` set. This means, as far as sb-edit is concerned, they are the top block in a script, and should be deserialized to `Script` instances as any other `topLevel` block would be.

(That flag is likely set by scratch-blocks as a simple mechanism for displacing any block from an input: if you place a block into a slot which already has a (non-shadow) block in it, you can see the block that was already there get kicked out of the input and placed to the side - at the top level of the workspace, since it's no longer inside a slot. In that regard, it simply fails to distinguish non-shadows from shadows, which don't have any user-apparent purpose for being stored `topLevel`.)

What is the effect of this? Well, outside of sb3 import/export, sb-edit has no concept of "shadow" blocks. (It has no need for them, since, unlike 3.0, sb-edit doesn't remember the value entered into an obscured input slot.) So, when exporting, these top-level blocks *won't be stored as shadow blocks.* Here's what the result looks like in Scratch 3.0:

![The block "switch to costume (join (costume) (2))" as formed earlier - and a mysterious, deep purple, reporter-shaped block, containing a non-droppable input menu with "costume2" selected.](https://user-images.githubusercontent.com/9948030/74675806-c2936e00-518a-11ea-9cff-551abbf2a774.png)

Scratch 3.0 will actually display that block, whose opcode is that of a typically-shadow block dropdown menu, as though it is an ordinary reporter! It behaves like a typical reporter, simply echoing the value selected in it; this does make it a useful "portable dropdown menu", but it's certainly not the expected result of serializing a block you've simply placed a reporter inside.

In the scratchblocks output, I had to [specifically catch and ignore these blocks](https://github.com/PullJosh/sb-edit/pull/15/commits/a168bd1e52adf3985c5bd9795e3ead292643eea1#diff-2914078279032d156af0a67fefc4ff93R519-R542) in order to avoid outputting the then-mysterious "menu blocks", ala this:

!["unknown block [looks_costume] [costume1]"](https://user-images.githubusercontent.com/9948030/74676359-41d57180-518c-11ea-9b6e-a982031c62d3.png)

While it would certainly be doable to add comparable catches to any output format, it's preferable to avoid having to reference the list of menu opcodes repeatedly like that. Instead, we target the root cause of the issue, which is that these menus are being imported as sb-edit blocks in the first place—and we do that by skipping top-level shadow blocks when converting SB3 blocks into sb-edit scripts.

(PS: This is probably the longest description I've written for a one-line change...but I promise that understanding what's here will help when reviewing the much larger sb3 export PR, coming [soon™](https://github.com/PullJosh/sb-edit/issues/28) to a repository near you!)