### PR TITLE
Use Number cast in optionalToNumber

### DIFF
--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -868,7 +868,7 @@ export default function toScratchJS(
     if (typeof value !== "string") {
       return value;
     }
-    const asNum = parseFloat(value);
+    const asNum = Number(value);
     if (!isNaN(asNum)) {
       return asNum;
     }


### PR DESCRIPTION
See https://github.com/towerofnix/sb-edit/pull/1 for more info--`isNaN(parseFloat(...))` doesn't accurately determine whether a value can be parsed as a number.