### PR TITLE
scratch-js: don't restringify number inputs

### DIFF
--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -230,7 +230,8 @@ export default function toScratchJS(
         default:
           const asNum = Number(input.value as string);
           if (!isNaN(asNum)) {
-            return JSON.stringify(asNum);
+            // Don't re-stringify; if this can be parsed as a number, use it as-is
+            return String(input.value);
           }
           return JSON.stringify(input.value);
       }


### PR DESCRIPTION
Resolves #9 

Currently, `sb-edit` compiles this:
![image](https://user-images.githubusercontent.com/25993062/75833886-6171ba00-5d88-11ea-826c-c8fba4d7548e.png)
into this:
```js
this.stage.vars.myVariable = 8355711;
```

With this PR, it compiles to this:
```js
this.stage.vars.myVariable = 0x7f7f7f;
```

If a value can be parsed as a `Number`, instead of re-stringifying the parsed value (which will result in a decimal literal), just use the unparsed value.