### PR TITLE
Second ESLint pass

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,11 +12,9 @@ module.exports = {
     'plugin:prettier/recommended'
   ],
   "rules": {
-    "object-literal-sort-keys": "off",
-    "no-shadowed-variable": "off",
     "prefer-const": "off",
-    "max-classes-per-file": "off",
-    "ordered-imports": "off",
-    "@typescript-eslint/camelcase": "off"
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/no-use-before-define": ["error", {"functions": false}],
+    "@typescript-eslint/no-this-alias": "off"
   }
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
-    "lint": "eslint src/**.ts",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "jest --config jestconfig.json",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -7,14 +7,14 @@ import { OpCode } from "../../OpCode";
 import * as prettier from "prettier";
 import Target from "../../Target";
 
-function triggerInitCode(script: Script) {
+function triggerInitCode(script: Script): string | null {
   const hat = script.hat;
 
   if (hat === null) {
     return null;
   }
 
-  const triggerInitStr = (name: string, options?: object) =>
+  const triggerInitStr = (name: string, options?: object): string =>
     `new Trigger(Trigger.${name}${options ? `, ${JSON.stringify(options)}` : ""}, this.${script.name})`;
 
   switch (hat.opcode) {
@@ -35,7 +35,7 @@ function triggerInitCode(script: Script) {
 }
 
 function uniqueNameGenerator(usedNames: string[] = []) {
-  function uniqueName(name) {
+  function uniqueName(name): string {
     if (!usedNames.includes(name)) {
       usedNames.push(name);
       return name;
@@ -56,7 +56,7 @@ function uniqueNameGenerator(usedNames: string[] = []) {
   return uniqueName;
 }
 
-function camelCase(name: string, upper = false) {
+function camelCase(name: string, upper = false): string {
   const validChars = /[^a-zA-Z0-9]/;
   const ignoredChars = /[']/g;
   let parts = name.replace(ignoredChars, "").split(validChars);
@@ -106,7 +106,7 @@ export default function toScratchJS(
           return `../${name}/${name}.mjs`;
       }
     },
-    getAssetURL: ({ type, target, name, md5, ext }) => {
+    getAssetURL: ({ type, target, name, ext }) => {
       switch (type) {
         case "costume":
           return `./${target}/costumes/${name}.${ext}`;

--- a/src/io/scratch-js/toScratchJS.ts
+++ b/src/io/scratch-js/toScratchJS.ts
@@ -56,7 +56,7 @@ function uniqueNameGenerator(usedNames: string[] = []) {
   return uniqueName;
 }
 
-function camelCase(name: string, upper: boolean = false) {
+function camelCase(name: string, upper = false) {
   const validChars = /[^a-zA-Z0-9]/;
   const ignoredChars = /[']/g;
   let parts = name.replace(ignoredChars, "").split(validChars);
@@ -227,12 +227,13 @@ export default function toScratchJS(
           return blockToJS(input.value as Block);
         case "blocks":
           return input.value.map(block => blockToJS(block as Block)).join(";\n");
-        default:
+        default: {
           const asNum = Number(input.value as string);
           if (!isNaN(asNum)) {
             return JSON.stringify(asNum);
           }
           return JSON.stringify(input.value);
+        }
       }
     }
 
@@ -584,13 +585,14 @@ export default function toScratchJS(
             case "volume":
               propName = null;
               break;
-            default:
+            default: {
               let varOwner: Target = project.stage;
               if (block.inputs.OBJECT.value !== "_stage_") {
                 varOwner = project.sprites.find(sprite => sprite.name === targetNameMap[block.inputs.OBJECT.value]);
               }
               propName = `vars[${JSON.stringify(variableNameMap.get(varOwner)[block.inputs.PROPERTY.value])}]`;
               break;
+            }
           }
 
           if (propName === null) {
@@ -622,6 +624,8 @@ export default function toScratchJS(
               return `(new Date().getMinutes())`;
             case "SECOND":
               return `(new Date().getSeconds())`;
+            default:
+              return `('')`;
           }
         case OpCode.sensing_dayssince2000:
           return `(((new Date().getTime() - new Date(2000, 0, 1)) / 1000 / 60 + new Date().getTimezoneOffset()) / 60 / 24)`;

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -26,12 +26,12 @@ export default function toScratchblocks(
       .join("\n");
   }
 
-  function input(inp: BlockInput.Any, target: Target, flag: boolean = false): string {
+  function input(inp: BlockInput.Any, target: Target, flag = false): string {
     if (!inp) {
       return "";
     }
 
-    const escape = (value: string): string => (value || "").toString().replace(/[()\[\]]|v$/g, m => "\\" + m);
+    const escape = (value: string): string => (value || "").toString().replace(/[()[\]]|v$/g, m => "\\" + m);
 
     switch (inp.type) {
       case "number":
@@ -50,13 +50,14 @@ export default function toScratchblocks(
       case "graphicEffect":
       case "soundEffect":
       case "currentMenu":
-      case "greaterThanMenu":
+      case "greaterThanMenu": {
         const value =
           {
             PAN: "pan left/right",
             DAYOFWEEK: "day of week"
           }[inp.value] || (inp.value || "").toLowerCase();
         return `[${escape(value)} v]`;
+      }
 
       case "variable":
       case "list":
@@ -106,9 +107,10 @@ export default function toScratchblocks(
           return `(${escape(inp.value)} v)`;
         }
 
-      case "color":
+      case "color": {
         const hex = (k: string): string => (inp.value || { r: 0, g: 0, b: 0 })[k].toString(16).padStart(2, "0");
         return `[#${hex("r") + hex("g") + hex("b")}]`;
+      }
 
       case "block":
         if (flag) {
@@ -149,7 +151,7 @@ export default function toScratchblocks(
 
     const i = (key: string, ...args): string => input(block.inputs[key], target, ...args);
     const operator = (op: string): string => `(${i("NUM1")} ${op} ${i("NUM2")})`;
-    const boolop = (op: string, flag: boolean = false): string => {
+    const boolop = (op: string, flag = false): string => {
       if (flag) {
         return `<${i("OPERAND1") || "<>"} ${op} ${i("OPERAND2") || "<>"}>`;
       } else {
@@ -455,7 +457,7 @@ export default function toScratchblocks(
         return `hide list ${i("LIST")}`;
 
       // custom blocks ----------------------------------------------- //
-      case OpCode.procedures_definition:
+      case OpCode.procedures_definition: {
         const spec = block.inputs.ARGUMENTS.value
           .map(({ type, name }) => {
             switch (type) {
@@ -469,7 +471,8 @@ export default function toScratchblocks(
           })
           .join(" ");
         return `define ${spec}` + (block.inputs.WARP.value ? " // run without screen refresh" : "");
-      case OpCode.procedures_call:
+      }
+      case OpCode.procedures_call: {
         const definition = target.scripts
           .map(s => s.blocks[0])
           .find(
@@ -494,6 +497,7 @@ export default function toScratchblocks(
         } else {
           return `... // missing custom block definition for ${block.inputs.PROCCODE.value}`;
         }
+      }
       case OpCode.argument_reporter_string_number:
         return `(${block.inputs.VALUE.value} :: custom-arg)`;
       case OpCode.argument_reporter_boolean:


### PR DESCRIPTION
- Fix `npm run lint` to recurse into subdirectories
- Remove old no-longer-applicable tslint rules
- Disable problematic rules
- Make toScratchJS.ts and toScratchblocks.ts pass lint